### PR TITLE
[Fix] - issue in search path where echo would evaluate the *

### DIFF
--- a/.github/workflows/terraform-plan-apply.yml
+++ b/.github/workflows/terraform-plan-apply.yml
@@ -76,7 +76,7 @@ jobs:
             scConfigImage=`echo $(jq -r '.spring_cloud.config_server.image_name' ./$path)`
             scConfigImageTag=`echo $(jq -r '.spring_cloud.config_server.image_tag' ./$path)`
             scConfigGitUri=`echo $(jq -r '.spring_cloud.config_server.git_uri' ./$path)`
-            scConfigSearchPaths=`echo $(jq -r '.spring_cloud.config_server.search_paths' ./$path)`
+            scConfigSearchPaths=`echo $(jq '.spring_cloud.config_server.search_paths' ./$path)`
 
             # in this section we add to the output (the matrix), a new block, which
             # contains all the read content from the definition file (e.g. the trial name,
@@ -92,7 +92,7 @@ jobs:
             MatrixItem="$MatrixItem \"sc_gateway_image_name\": \"$scGatewayImage\",\"sc_gateway_image_tag\": \"$scGatewayImageTag\","
             MatrixItem="$MatrixItem \"sc_discovery_image_name\": \"$scDiscoveryImage\",\"sc_discovery_image_tag\": \"$scDiscoveryImageTag\","
             MatrixItem="$MatrixItem \"sc_config_image_name\": \"$scConfigImage\",\"sc_config_image_tag\": \"$scConfigImageTag\","
-            MatrixItem="$MatrixItem \"sc_config_git_uri\": \"$scConfigGitUri\",\"sc_config_search_paths\": \"$scConfigSearchPaths\","
+            MatrixItem="$MatrixItem \"sc_config_git_uri\": \"$scConfigGitUri\",\"sc_config_search_paths\": $scConfigSearchPaths,"
 
             MatrixItem="$MatrixItem },"
             JSON="$JSON$MatrixItem"

--- a/sample_trial/services/practitioner-service/practitioner-service.properties
+++ b/sample_trial/services/practitioner-service/practitioner-service.properties
@@ -1,2 +1,5 @@
+# uri's should be deleted when discovery works
 fhir.uri=http://fhir-api:8080
+role.service.uri=http://role-service:8080
+
 server.error.include-message=always


### PR DESCRIPTION
## Description
When setting search paths to xxx/*, the github action parsed it into the actual list of files. 
removed the jq -r option to get this as a string.

also added to the practitioner's props file, the roles uri. which is a place holder (value doesnt work currently and needs the discovery service). this is for the practitioner role to be able to start

### Checklist:

- [ ] Branch name follows convention (feature/arts-###-short-name OR fix/arts-###-short-name)
- [ ] I have included a short-meaningful title, description and changes for this PR
