### PR TITLE
[ARTS-637] Adding missing cross micro services uri for e2e operation

### DIFF
--- a/sample_trial/services/practitioner-service/application-dev.yml
+++ b/sample_trial/services/practitioner-service/application-dev.yml
@@ -1,14 +1,6 @@
 server:
   error:
     include-message: always
-fhir:
-  uri: http://fhir-api:8080
-role:
-  service:
-    uri: http://role-service:8080
-site:
-  service:
-    uri: http://role-service:8080
 
 ---
 config:

--- a/terraform/trial_rg/modules/fhir/outputs.tf
+++ b/terraform/trial_rg/modules/fhir/outputs.tf
@@ -2,3 +2,8 @@ output "service_id" {
   value       = azurerm_app_service.fhir_server.id
   description = "The fhir app service id."
 }
+
+output "hostname" {
+  value       = "https://${azurerm_app_service.fhir_server.default_site_hostname}"
+  description = "The default hostname of the web app."
+}

--- a/terraform/trial_rg/services.tf
+++ b/terraform/trial_rg/services.tf
@@ -28,12 +28,14 @@ module "trial_app_service_site" {
     "WEBSITES_PORT"                           = "80"
     "EUREKA_CLIENT_SERVICEURL_DEFAULTZONE"    = "${module.trial_sc_discovery.hostname}/eureka/"
     "EUREKA_INSTANCE_HOSTNAME"                = "${local.site_name}.azurewebsites.net"
+    "FHIR_URI"                                = module.fhir_server.hostname
   }
 
   depends_on = [
     azurerm_app_service_plan.apps_service_plan,
     module.trial_sc_config,
     module.trial_sc_discovery,
+    module.fhir_server,
   ]
 }
 
@@ -56,12 +58,18 @@ module "trial_app_service_practitioner" {
     "WEBSITES_PORT"                           = "80"
     "EUREKA_CLIENT_SERVICEURL_DEFAULTZONE"    = "${module.trial_sc_discovery.hostname}/eureka/"
     "EUREKA_INSTANCE_HOSTNAME"                = "${local.practitioner_name}.azurewebsites.net"
+    "FHIR_URI"                                = module.fhir_server.hostname
+    "ROLE_SERVICE_URI"                        = module.trial_app_service_role.hostname
+    "SITE_SERVICE_URI"                        = module.trial_app_service_site.hostname
   }
 
   depends_on = [
     azurerm_app_service_plan.apps_service_plan,
     module.trial_sc_config,
     module.trial_sc_discovery,
+    module.trial_app_service_site,
+    module.trial_app_service_role,
+    module.fhir_server,
   ]
 }
 


### PR DESCRIPTION
## Description
Until the discovery will be fully functioning (with inter-services) communication, Adding the URI explicitly so the Azure deployment will work E2E

### Changes
- [ARTS-637] - Adding explicit URI (temp)

### Checklist:

- [x] Branch name follows convention (feature/arts-###-short-name OR fix/arts-###-short-name)
- [x] I have included a short-meaningful title, description and changes for this PR


[ARTS-637]: https://ndph-arts.atlassian.net/browse/ARTS-637