### PR TITLE
[ARTS-527] Practitioner connects to other services using discovery server

### DIFF
--- a/sample_trial/services/practitioner-service/application-dev.yml
+++ b/sample_trial/services/practitioner-service/application-dev.yml
@@ -1,7 +1,12 @@
 server:
   error:
     include-message: always
-
+role:
+  service:
+    uri: http://role-service
+site:
+  service:
+    uri: http://site-service
 ---
 config:
   name: Practitioner

--- a/terraform/trial_rg/services.tf
+++ b/terraform/trial_rg/services.tf
@@ -59,8 +59,6 @@ module "trial_app_service_practitioner" {
     "EUREKA_CLIENT_SERVICEURL_DEFAULTZONE"    = "${module.trial_sc_discovery.hostname}/eureka/"
     "EUREKA_INSTANCE_HOSTNAME"                = "${local.practitioner_name}.azurewebsites.net"
     "FHIR_URI"                                = module.fhir_server.hostname
-    "ROLE_SERVICE_URI"                        = module.trial_app_service_role.hostname
-    "SITE_SERVICE_URI"                        = module.trial_app_service_site.hostname
   }
 
   depends_on = [


### PR DESCRIPTION
## Description
First client implementation of connectivity between services from the practitioner service
Approve together with [this](https://github.com/NDPH-ARTS/mts-services/pull/139) PR.

### Changes
- [ARTS-527] - Practitioner using discovery server in order to connect to other services

### Checklist:

- [x] Branch name follows convention (feature/arts-###-short-name OR fix/arts-###-short-name)
- [x] I have included a short-meaningful title, description and changes for this PR


[ARTS-527]: https://ndph-arts.atlassian.net/browse/ARTS-527