### PR TITLE
[ARTS-663] Add config for init-service

### DIFF
--- a/sample_trial/services/init-service/application-dev.yml
+++ b/sample_trial/services/init-service/application-dev.yml
@@ -1,0 +1,41 @@
+server:
+  error:
+    include-message: always
+
+logging:
+  level:
+    uk:
+      ac:
+        ox:
+          ndph:
+            mts: DEBUG
+    org:
+      springframework:
+        web:
+          reactive:
+            function:
+              client:
+                ExchangeFunctions: TRACE
+delay-start: 30
+---
+trial:
+  trialName: "My Dev Sample Trial"
+  persons:
+    - givenName: Bootstrap
+      familyName: User
+      prefix: Mr
+      roles:
+        - superuser
+      userAccount: some-user-account-id
+  sites:
+    - name: CCO
+      alias: CCO
+      siteType: CCO
+  roles:
+    - id: superuser
+      permissions:
+        - id: create-person
+        - id: view-person
+    - id: country-admin
+      permissions:
+        - id: create-person


### PR DESCRIPTION
## Description
This is to support init-service getting its config from the config-server.

### Changes
- [ARTS-663]

### Checklist:

- [x] Branch name follows convention (feature/arts-###-short-name OR fix/arts-###-short-name)
- [x] I have included a short-meaningful title, description and changes for this PR


[ARTS-663]: https://ndph-arts.atlassian.net/browse/ARTS-663