### PR TITLE
Tag trial's resource group with github user

### DIFF
--- a/.github/workflows/terraform-plan-apply.yml
+++ b/.github/workflows/terraform-plan-apply.yml
@@ -156,7 +156,7 @@ jobs:
           set -o errexit
           set -o nounset
 
-          terraform plan -var-file=${{ matrix.trial_name }}.tfvars
+          terraform plan -var-file=${{ matrix.trial_name }}.tfvars -var="owner=${{ github.actor }}"
 
       # Apply, only on merge to main
       - name: Apply TF for "${{ matrix.trial_name }}"
@@ -166,7 +166,7 @@ jobs:
           set -o nounset
 
           echo "Merged to main. applying trial's RG"
-          terraform apply -var-file=${{ matrix.trial_name }}.tfvars -auto-approve
+          terraform apply -var-file=${{ matrix.trial_name }}.tfvars -var="owner=${{ github.actor }}" -auto-approve
 
           # '-raw' is important so no other characters will be added
           ui_storage_conn_string=$(terraform output -raw ui_conn_string)

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -3,6 +3,7 @@ module "trial_rg" {
   source                  = "./trial_rg"
   trial_name              = var.trial_name
   environment             = var.environment
+  owner                   = var.owner
   site_image_name         = var.site_image_name
   site_image_tag          = var.site_image_tag
   practitioner_image_name = var.practitioner_image_name

--- a/terraform/trial_rg/main.tf
+++ b/terraform/trial_rg/main.tf
@@ -4,7 +4,7 @@ resource "azurerm_resource_group" "trial_rg" {
   name     = "rg-trial-${var.trial_name}-${var.environment}"
   location = var.location
   tags = {
-    Owner = "user@contoso.com"
+    Owner = "${var.owner}"
   }
 }
 

--- a/terraform/trial_rg/variables.tf
+++ b/terraform/trial_rg/variables.tf
@@ -116,3 +116,9 @@ variable "spring_config_label" {
   type        = string
   description = "Spring cloud label (branch)."
 }
+
+variable "owner" {
+  type        = string
+  description = "The owner of the trial environment."
+  default     = "unknown"
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -112,3 +112,9 @@ variable "spring_config_label" {
   type        = string
   description = "Spring cloud label (branch)."
 }
+
+variable "owner" {
+  type        = string
+  description = "The owner of the trial environment."
+  default     = "unknown"
+}


### PR DESCRIPTION
## Description
Include the github username creating/updating a trial resource group as a tag. This way we can track ownership and manage our resources better.

### Checklist:

- [ ] Branch name follows convention (feature/arts-###-short-name OR fix/arts-###-short-name)
- [x] I have included a short-meaningful title, description and changes for this PR
