### PR TITLE
[ARTS-753] Pick up latest UI release by default

### DIFF
--- a/.github/workflows/terraform-plan-apply.yml
+++ b/.github/workflows/terraform-plan-apply.yml
@@ -218,7 +218,7 @@ jobs:
           set -o errexit
           set -o nounset
 
-          wget https://github.com/NDPH-ARTS/mts-trial-ui/releases/download/branding-assets/mts-trial-ui.zip
+          wget https://github.com/NDPH-ARTS/mts-trial-ui/releases/latest/download/mts-trial-ui.zip
 
       # Unzip & Customize (replace values)
       - name: UI component - Unzip and modify


### PR DESCRIPTION
## Description
We were always deploying a fixed prior release of the UI, change to pick up the latest release as a default

### Changes
- [ARTS-753] - Change url in teraform-plan-apply

### Checklist:

- [x] Branch name follows convention (feature/arts-###-short-name OR fix/arts-###-short-name)
- [x] I have included a short-meaningful title, description and changes for this PR


[ARTS-753]: https://ndph-arts.atlassian.net/browse/ARTS-753