### PR TITLE
[ARTS-355] - Limit public/internet access to API services

### DIFF
--- a/terraform/trial_rg/modules/fhir/main.tf
+++ b/terraform/trial_rg/modules/fhir/main.tf
@@ -9,16 +9,18 @@ resource "random_password" "fhir_sql_password" {
 
 # Deploy a sql server and db for fhir before we create the web app
 module "fhir_sql_server" {
-  source      = "../sql"
-  trial_name  = var.trial_name
-  rg_name     = var.rg_name
-  vnet_id     = var.vnet_id
-  subnet_id   = var.endpointsubnet
-  db_name     = "FHIR"
-  app_name    = "fhir"
-  sql_user    = var.fhir_sqluser
-  sql_pass    = random_password.fhir_sql_password.result
-  application = "sql-fhir"
+  source        = "../sql"
+  trial_name    = var.trial_name
+  rg_name       = var.rg_name
+  vnet_id       = var.vnet_id
+  subnet_id     = var.endpointsubnet
+  db_name       = "FHIR"
+  app_name      = "fhir"
+  sql_user      = var.fhir_sqluser
+  sql_pass      = random_password.fhir_sql_password.result
+  application   = "sql-fhir"
+  dns_zone_name = var.sql_dns_zone_name
+  dns_zone_id   = var.sql_dns_zone_id
 }
 
 # Fhir server

--- a/terraform/trial_rg/modules/fhir/variables.tf
+++ b/terraform/trial_rg/modules/fhir/variables.tf
@@ -63,3 +63,13 @@ variable "app_insights_key" {
   type        = string
   description = "The instrumentation key of app insights"
 }
+
+variable "sql_dns_zone_name" {
+  type        = string
+  description = "DNS zone name for sql servers."
+}
+
+variable "sql_dns_zone_id" {
+  type        = string
+  description = "The id of the given dns zone."
+}

--- a/terraform/trial_rg/modules/genericservice/main.tf
+++ b/terraform/trial_rg/modules/genericservice/main.tf
@@ -30,3 +30,22 @@ resource "azurerm_app_service" "generic_service" {
 
   app_settings = var.settings
 }
+
+# count = 0, if this is the gateway and no private endpoint is needed
+module "private_endpoint" {
+  count            = var.no_private_endpoint == true ? 0 : 1
+  source           = "../privateendpoint"
+  trial_name       = var.trial_name
+  rg_name          = var.rg_name
+  resource_id      = azurerm_app_service.generic_service.id
+  vnet_id          = var.vnet_id
+  subnet_id        = var.subnet_id
+  subresource_name = "sites"
+  application      = var.app_name
+  dns_zone_name    = var.dns_zone_name
+  dns_zone_id      = var.dns_zone_id
+
+  depends_on = [
+    azurerm_app_service.generic_service,
+  ]
+}

--- a/terraform/trial_rg/modules/genericservice/main.tf
+++ b/terraform/trial_rg/modules/genericservice/main.tf
@@ -33,7 +33,7 @@ resource "azurerm_app_service" "generic_service" {
 
 # count = 0, if this is the gateway and no private endpoint is needed
 module "private_endpoint" {
-  count            = var.no_private_endpoint == true ? 0 : 1
+  count            = var.enable_private_endpoint == true ? 1 : 0
   source           = "../privateendpoint"
   trial_name       = var.trial_name
   rg_name          = var.rg_name

--- a/terraform/trial_rg/modules/genericservice/variables.tf
+++ b/terraform/trial_rg/modules/genericservice/variables.tf
@@ -73,8 +73,8 @@ variable "dns_zone_id" {
   description = "The id of the given dns zone."
 }
 
-variable "no_private_endpoint" {
+variable "enable_private_endpoint" {
   type        = bool
-  description = "if 'true' then for this web app, private endpoint will not be created."
-  default     = false
+  description = "if 'false' then for this web app, private endpoint will NOT be created."
+  default     = true
 }

--- a/terraform/trial_rg/modules/genericservice/variables.tf
+++ b/terraform/trial_rg/modules/genericservice/variables.tf
@@ -48,7 +48,33 @@ variable "location" {
 }
 
 variable "settings" {
-  type = map(any)
-  default = {}
+  type      = map(any)
+  default   = {}
   sensitive = true
+}
+
+variable "vnet_id" {
+  type        = string
+  description = "The vnet id."
+}
+
+variable "subnet_id" {
+  type        = string
+  description = "The subnet id of the web app."
+}
+
+variable "dns_zone_name" {
+  type        = string
+  description = "DNS zone name for web apps."
+}
+
+variable "dns_zone_id" {
+  type        = string
+  description = "The id of the given dns zone."
+}
+
+variable "no_private_endpoint" {
+  type        = bool
+  description = "if 'true' then for this web app, private endpoint will not be created."
+  default     = false
 }

--- a/terraform/trial_rg/modules/kv/main.tf
+++ b/terraform/trial_rg/modules/kv/main.tf
@@ -15,21 +15,20 @@ resource "azurerm_key_vault" "trial_keyvault" {
   }
 }
 
-# TODO: correct this and uncomment
-
 # Connect KV to a new private endpoint
-# module "private_endpoint" {
-#   source                = "../privateendpoint"
-#   trial_name            = var.trial_name
-#   rg_name               = var.rg_name
-#   resource_name         = azurerm_key_vault.trial_keyvault.name
-#   resource_id           = azurerm_key_vault.trial_keyvault.id
-#   vnet_id               = var.vnet_id
-#   subnet_id             = var.subnet_id
-#   kv                    = true
-#   application           = "kv"
+module "private_endpoint" {
+  source           = "../privateendpoint"
+  trial_name       = var.trial_name
+  rg_name          = var.rg_name
+  resource_id      = azurerm_key_vault.trial_keyvault.id
+  vnet_id          = var.vnet_id
+  subnet_id        = var.subnet_id
+  subresource_name = "vault"
+  application      = "kv"
+  dns_zone_name    = var.dns_zone_name
+  dns_zone_id      = var.dns_zone_id
 
-#   depends_on = [
-#     azurerm_key_vault.trial_keyvault,
-#   ]
-# }
+  depends_on = [
+    azurerm_key_vault.trial_keyvault,
+  ]
+}

--- a/terraform/trial_rg/modules/kv/variables.tf
+++ b/terraform/trial_rg/modules/kv/variables.tf
@@ -40,3 +40,13 @@ variable "subnet_id" {
   type        = string
   description = "The subnet to be integrated into."
 }
+
+variable "dns_zone_name" {
+  type        = string
+  description = "DNS zone name for key vaults."
+}
+
+variable "dns_zone_id" {
+  type        = string
+  description = "The id of the given dns zone."
+}

--- a/terraform/trial_rg/modules/privateendpoint/main.tf
+++ b/terraform/trial_rg/modules/privateendpoint/main.tf
@@ -5,7 +5,7 @@ resource "azurerm_private_endpoint" "private_endpoint" {
   subnet_id           = var.subnet_id
 
   private_dns_zone_group {
-    name                 = "${var.application}privatednszonegroup"
+    name                 = "${var.application}-private-dns-zone-group"
     private_dns_zone_ids = [var.dns_zone_id]
   }
 
@@ -22,13 +22,4 @@ data "azurerm_private_endpoint_connection" "endpoint-connection" {
   depends_on          = [azurerm_private_endpoint.private_endpoint]
   name                = azurerm_private_endpoint.private_endpoint.name
   resource_group_name = var.rg_name
-}
-
-# Create a Resource's Private DNS A Record
-resource "azurerm_private_dns_a_record" "endpoint-dns-a-record" {
-  name                = lower("${var.application}-dns-record")
-  zone_name           = var.dns_zone_name
-  resource_group_name = var.rg_name
-  ttl                 = 300
-  records             = [data.azurerm_private_endpoint_connection.endpoint-connection.private_service_connection.0.private_ip_address]
 }

--- a/terraform/trial_rg/modules/privateendpoint/main.tf
+++ b/terraform/trial_rg/modules/privateendpoint/main.tf
@@ -1,18 +1,3 @@
-# Create a Resource's Private DNS Zone
-resource "azurerm_private_dns_zone" "endpoint-dns-private-zone" {
-  # name                = var.sql ? "${var.resource_name}.database.windows.net" : "${var.resource_name}.vault.azure.net"
-  name                = var.sql ? "privatelink.database.windows.net" : "privatelink.vaultcore.azure.net"
-  resource_group_name = var.rg_name
-}
-
-# Create a Private DNS to VNET link
-resource "azurerm_private_dns_zone_virtual_network_link" "dns-zone-to-vnet-link" {
-  name                  = "${var.application}-vnet-link"
-  resource_group_name   = var.rg_name
-  private_dns_zone_name = azurerm_private_dns_zone.endpoint-dns-private-zone.name
-  virtual_network_id    = var.vnet_id
-}
-
 resource "azurerm_private_endpoint" "private_endpoint" {
   name                = "pe-${var.trial_name}-${var.application}-${var.environment}"
   location            = var.location
@@ -21,14 +6,14 @@ resource "azurerm_private_endpoint" "private_endpoint" {
 
   private_dns_zone_group {
     name                 = "${var.application}privatednszonegroup"
-    private_dns_zone_ids = [azurerm_private_dns_zone.endpoint-dns-private-zone.id]
+    private_dns_zone_ids = [var.dns_zone_id]
   }
 
   private_service_connection {
     name                           = "psc-${var.trial_name}-${var.application}-${var.environment}"
     private_connection_resource_id = var.resource_id
     is_manual_connection           = false
-    subresource_names              = [var.sql ? "sqlServer" : "vault"]
+    subresource_names              = [var.subresource_name]
   }
 }
 
@@ -42,7 +27,7 @@ data "azurerm_private_endpoint_connection" "endpoint-connection" {
 # Create a Resource's Private DNS A Record
 resource "azurerm_private_dns_a_record" "endpoint-dns-a-record" {
   name                = lower("${var.application}-dns-record")
-  zone_name           = azurerm_private_dns_zone.endpoint-dns-private-zone.name
+  zone_name           = var.dns_zone_name
   resource_group_name = var.rg_name
   ttl                 = 300
   records             = [data.azurerm_private_endpoint_connection.endpoint-connection.private_service_connection.0.private_ip_address]

--- a/terraform/trial_rg/modules/privateendpoint/variables.tf
+++ b/terraform/trial_rg/modules/privateendpoint/variables.tf
@@ -26,11 +26,6 @@ variable "environment" {
   default     = "dev"
 }
 
-variable "resource_name" {
-  type        = string
-  description = "The resource name that is connected to the private link."
-}
-
 variable "resource_id" {
   type        = string
   description = "The resource id that is connected to the private link."
@@ -58,19 +53,23 @@ variable "vnet_id" {
   description = "The vnet id."
 }
 
-variable "kv" {
-  type        = bool
-  description = "is related to kv."
-  default     = false
-}
-
-variable "sql" {
-  type        = bool
-  description = "is related to sql."
-  default     = false
+variable "subresource_name" {
+  type = string
+  # https://docs.microsoft.com/en-us/azure/private-link/private-endpoint-overview#private-link-resource
+  description = "The subresource to protect (kv/sql/webapp)"
 }
 
 variable "application" {
   type        = string
   description = "The application this endpoints relates to (workload)."
+}
+
+variable "dns_zone_name" {
+  type        = string
+  description = "DNS zone name for web apps/kv/sqlservers."
+}
+
+variable "dns_zone_id" {
+  type        = string
+  description = "The id of the given dns zone."
 }

--- a/terraform/trial_rg/modules/sql/main.tf
+++ b/terraform/trial_rg/modules/sql/main.tf
@@ -1,13 +1,14 @@
 
 # SQL server
 resource "azurerm_mssql_server" "sql_server" {
-  name                          = "sql-server-${var.trial_name}-${var.app_name}-${var.environment}"
-  location                      = var.location
-  resource_group_name           = var.rg_name
-  version                       = "12.0"
-  administrator_login           = var.sql_user
-  administrator_login_password  = var.sql_pass
-  public_network_access_enabled = true # TODO: set to false when private link works
+  name                         = "sql-server-${var.trial_name}-${var.app_name}-${var.environment}"
+  location                     = var.location
+  resource_group_name          = var.rg_name
+  version                      = "12.0"
+  administrator_login          = var.sql_user
+  administrator_login_password = var.sql_pass
+  # Block external communication
+  public_network_access_enabled = false
 
 }
 
@@ -23,28 +24,16 @@ resource "azurerm_mssql_database" "sqldb" {
   ]
 }
 
-# TODO: currect this and uncomment
-
 # After the SQL server is deployed, connect it to a new private endpoint
-# module "private_endpoint" {
-#   source        = "../privateendpoint"
-#   trial_name    = var.trial_name
-#   rg_name       = var.rg_name
-#   resource_name = azurerm_mssql_server.sql_server.name
-#   resource_id   = azurerm_mssql_server.sql_server.id
-#   vnet_id       = var.vnet_id
-#   subnet_id     = var.subnet_id
-#   sql           = true
-#   application   = var.application
-# }
-
-
-# TODO: delete this when private endpoints work.
-# Allow access for azure services
-resource "azurerm_sql_firewall_rule" "example" {
-  name                = "FirewallRule1"
-  resource_group_name = azurerm_mssql_server.sql_server.resource_group_name
-  server_name         = azurerm_mssql_server.sql_server.name
-  start_ip_address    = "0.0.0.0"
-  end_ip_address      = "0.0.0.0"
+module "private_endpoint" {
+  source           = "../privateendpoint"
+  trial_name       = var.trial_name
+  rg_name          = var.rg_name
+  resource_id      = azurerm_mssql_server.sql_server.id
+  vnet_id          = var.vnet_id
+  subnet_id        = var.subnet_id
+  subresource_name = "sqlServer"
+  application      = var.application
+  dns_zone_name    = var.dns_zone_name
+  dns_zone_id      = var.dns_zone_id
 }

--- a/terraform/trial_rg/modules/sql/variables.tf
+++ b/terraform/trial_rg/modules/sql/variables.tf
@@ -60,3 +60,14 @@ variable "application" {
   type        = string
   description = "The application this endpoints relates to (workload)."
 }
+
+variable "dns_zone_name" {
+  type        = string
+  description = "DNS zone name for sql servers."
+}
+
+variable "dns_zone_id" {
+  type        = string
+  description = "The id of the given dns zone."
+}
+

--- a/terraform/trial_rg/modules/vnet/main.tf
+++ b/terraform/trial_rg/modules/vnet/main.tf
@@ -23,9 +23,56 @@ resource "azurerm_subnet" "integrationsubnet" {
 
 ## endpoint subnet
 resource "azurerm_subnet" "endpointsubnet" {
-  name                                           = "endpointsubnet"
-  resource_group_name                            = var.rg_name
-  virtual_network_name                           = azurerm_virtual_network.vnet.name
-  address_prefixes                               = ["10.0.2.0/24"]
+  name                 = "endpointsubnet"
+  resource_group_name  = var.rg_name
+  virtual_network_name = azurerm_virtual_network.vnet.name
+  address_prefixes     = ["10.0.2.0/24"]
+  # https://docs.microsoft.com/en-us/azure/private-link/disable-private-link-service-network-policy
   enforce_private_link_endpoint_network_policies = true
+}
+
+# Create a Resource's Private DNS Zone
+resource "azurerm_private_dns_zone" "kv-endpoint-dns-private-zone" {
+  # https://docs.microsoft.com/en-us/azure/architecture/example-scenario/private-web-app/private-web-app#dns-configured-on-app-service
+  name                = "privatelink.vault.azure.net"
+  resource_group_name = var.rg_name
+}
+
+# Create a Resource's Private DNS Zone
+resource "azurerm_private_dns_zone" "sql-endpoint-dns-private-zone" {
+  # https://docs.microsoft.com/en-us/azure/architecture/example-scenario/private-web-app/private-web-app#dns-configured-on-app-service
+  name                = "privatelink.database.windows.net"
+  resource_group_name = var.rg_name
+}
+
+
+# Create a Resource's Private DNS Zone
+resource "azurerm_private_dns_zone" "web-app-endpoint-dns-private-zone" {
+  # https://docs.microsoft.com/en-us/azure/architecture/example-scenario/private-web-app/private-web-app#dns-configured-on-app-service
+  name                = "privatelink.azurewebsites.net"
+  resource_group_name = var.rg_name
+}
+
+# Create a Private DNS to VNET link
+resource "azurerm_private_dns_zone_virtual_network_link" "sql-dns-zone-to-vnet-link" {
+  name                  = "sql-vnet-link"
+  resource_group_name   = var.rg_name
+  private_dns_zone_name = azurerm_private_dns_zone.sql-endpoint-dns-private-zone.name
+  virtual_network_id    = azurerm_virtual_network.vnet.id
+}
+
+# Create a Private DNS to VNET link
+resource "azurerm_private_dns_zone_virtual_network_link" "kv-dns-zone-to-vnet-link" {
+  name                  = "kv-vnet-link"
+  resource_group_name   = var.rg_name
+  private_dns_zone_name = azurerm_private_dns_zone.kv-endpoint-dns-private-zone.name
+  virtual_network_id    = azurerm_virtual_network.vnet.id
+}
+
+# Create a Private DNS to VNET link
+resource "azurerm_private_dns_zone_virtual_network_link" "web-app-dns-zone-to-vnet-link" {
+  name                  = "wa-vnet-link"
+  resource_group_name   = var.rg_name
+  private_dns_zone_name = azurerm_private_dns_zone.web-app-endpoint-dns-private-zone.name
+  virtual_network_id    = azurerm_virtual_network.vnet.id
 }

--- a/terraform/trial_rg/modules/vnet/outputs.tf
+++ b/terraform/trial_rg/modules/vnet/outputs.tf
@@ -12,3 +12,33 @@ output "id" {
   value       = azurerm_virtual_network.vnet.id
   description = "The generated vnet id."
 }
+
+output "sql_dns_zone_name" {
+  value       = azurerm_private_dns_zone.sql-endpoint-dns-private-zone.name
+  description = "DNS zone name for sql servers"
+}
+
+output "sql_dns_zone_id" {
+  value       = azurerm_private_dns_zone.sql-endpoint-dns-private-zone.id
+  description = "The id of the given dns zone."
+}
+
+output "kv_dns_zone_name" {
+  value       = azurerm_private_dns_zone.kv-endpoint-dns-private-zone.name
+  description = "DNS zone name for key vaults."
+}
+
+output "kv_dns_zone_id" {
+  value       = azurerm_private_dns_zone.kv-endpoint-dns-private-zone.id
+  description = "The id of the given dns zone."
+}
+
+output "webapp_dns_zone_name" {
+  value       = azurerm_private_dns_zone.web-app-endpoint-dns-private-zone.name
+  description = "DNS zone name for web applications."
+}
+
+output "webapp_dns_zone_id" {
+  value       = azurerm_private_dns_zone.web-app-endpoint-dns-private-zone.id
+  description = "The id of the given dns zone."
+}

--- a/terraform/trial_rg/services.tf
+++ b/terraform/trial_rg/services.tf
@@ -173,15 +173,15 @@ module "trial_app_service_init" {
 
 # config server service
 module "trial_sc_gateway" {
-  source              = "./modules/genericservice"
-  app_name            = local.gateway_name
-  rg_name             = azurerm_resource_group.trial_rg.name
-  app_service_plan_id = azurerm_app_service_plan.apps_service_plan.id
-  trial_name          = var.trial_name
-  environment         = var.environment
-  docker_image        = var.sc_gateway_image_name
-  docker_image_tag    = var.sc_gateway_image_tag
-  no_private_endpoint = true
+  source                  = "./modules/genericservice"
+  app_name                = local.gateway_name
+  rg_name                 = azurerm_resource_group.trial_rg.name
+  app_service_plan_id     = azurerm_app_service_plan.apps_service_plan.id
+  trial_name              = var.trial_name
+  environment             = var.environment
+  docker_image            = var.sc_gateway_image_name
+  docker_image_tag        = var.sc_gateway_image_tag
+  enable_private_endpoint = false
 
   # These variables are not used due to the fact we don't create a private endpoint
   # for the gateway, but are required by tf

--- a/terraform/trial_rg/services.tf
+++ b/terraform/trial_rg/services.tf
@@ -16,7 +16,9 @@ locals {
     "APPLICATIONINSIGHTS_CONNECTION_STRING" = azurerm_application_insights.app_insights.connection_string
     "EUREKA_CLIENT_SERVICEURL_DEFAULTZONE"  = "${module.trial_sc_discovery.hostname}/eureka/"
     # TODO: try to move back to a managed identity
-    "INIT_SERVICE_IDENTITY"    = "e6fd67af-ef25-4a4b-af7c-0ed8a7bd40cf" # module.trial_app_service_init.identity
+    "INIT_SERVICE_IDENTITY"  = "e6fd67af-ef25-4a4b-af7c-0ed8a7bd40cf" # module.trial_app_service_init.identity
+    "WEBSITE_DNS_SERVER"     = "168.63.129.16"
+    "WEBSITE_VNET_ROUTE_ALL" = 1
   }
 }
 
@@ -30,6 +32,10 @@ module "trial_app_service_site" {
   environment         = var.environment
   docker_image        = var.site_image_name
   docker_image_tag    = var.site_image_tag
+  vnet_id             = module.trial_vnet.id
+  subnet_id           = module.trial_vnet.endpointsubnet
+  dns_zone_name       = module.trial_vnet.webapp_dns_zone_name
+  dns_zone_id         = module.trial_vnet.webapp_dns_zone_id
 
   settings = merge(
     local.common_settings,
@@ -46,6 +52,7 @@ module "trial_app_service_site" {
     module.trial_sc_discovery,
     module.fhir_server,
     module.trial_app_service_init,
+    module.trial_vnet,
   ]
 }
 
@@ -59,6 +66,10 @@ module "trial_app_service_practitioner" {
   environment         = var.environment
   docker_image        = var.practitioner_image_name
   docker_image_tag    = var.practitioner_image_tag
+  vnet_id             = module.trial_vnet.id
+  subnet_id           = module.trial_vnet.endpointsubnet
+  dns_zone_name       = module.trial_vnet.webapp_dns_zone_name
+  dns_zone_id         = module.trial_vnet.webapp_dns_zone_id
 
   # todo use private endpoint
   settings = merge(
@@ -80,6 +91,7 @@ module "trial_app_service_practitioner" {
     module.trial_app_service_role,
     module.fhir_server,
     module.trial_app_service_init,
+    module.trial_vnet,
   ]
 }
 
@@ -93,15 +105,19 @@ module "trial_app_service_role" {
   environment         = var.environment
   docker_image        = var.role_image_name
   docker_image_tag    = var.role_image_tag
+  vnet_id             = module.trial_vnet.id
+  subnet_id           = module.trial_vnet.endpointsubnet
+  dns_zone_name       = module.trial_vnet.webapp_dns_zone_name
+  dns_zone_id         = module.trial_vnet.webapp_dns_zone_id
 
   settings = merge(
     local.common_settings,
     {
       "EUREKA_INSTANCE_HOSTNAME" = "${local.role_name}.azurewebsites.net"
       # TODO: this setting should be fetched from the config server
-      "JDBC_DRIVER"           = "com.microsoft.sqlserver.jdbc.SQLServerDriver"
+      "JDBC_DRIVER" = "com.microsoft.sqlserver.jdbc.SQLServerDriver"
       # TODO: replace with KeyVault reference
-      "JDBC_URL"                 = "jdbc:sqlserver://${module.roles_sql_server.sqlserver_name}.database.windows.net:1433;databaseName=ROLES;user=${module.roles_sql_server.db_user};password=${module.roles_sql_server.db_password}"
+      "JDBC_URL" = "jdbc:sqlserver://${module.roles_sql_server.sqlserver_name}.database.windows.net:1433;databaseName=ROLES;user=${module.roles_sql_server.db_user};password=${module.roles_sql_server.db_password}"
     },
   )
 
@@ -112,6 +128,7 @@ module "trial_app_service_role" {
     module.trial_sc_config,
     module.trial_sc_discovery,
     module.trial_app_service_init,
+    module.trial_vnet,
   ]
 }
 
@@ -126,6 +143,10 @@ module "trial_app_service_init" {
   environment         = var.environment
   docker_image        = var.init_service_image_name
   docker_image_tag    = var.init_service_image_tag
+  vnet_id             = module.trial_vnet.id
+  subnet_id           = module.trial_vnet.endpointsubnet
+  dns_zone_name       = module.trial_vnet.webapp_dns_zone_name
+  dns_zone_id         = module.trial_vnet.webapp_dns_zone_id
 
   settings = merge(
     local.common_settings,
@@ -142,6 +163,7 @@ module "trial_app_service_init" {
     azurerm_application_insights.app_insights,
     module.trial_sc_config,
     module.trial_sc_discovery,
+    module.trial_vnet,
   ]
 }
 
@@ -159,6 +181,14 @@ module "trial_sc_gateway" {
   environment         = var.environment
   docker_image        = var.sc_gateway_image_name
   docker_image_tag    = var.sc_gateway_image_tag
+  no_private_endpoint = true
+
+  # These variables are not used due to the fact we don't create a private endpoint
+  # for the gateway, but are required by tf
+  vnet_id       = module.trial_vnet.id
+  subnet_id     = module.trial_vnet.endpointsubnet
+  dns_zone_name = module.trial_vnet.webapp_dns_zone_name
+  dns_zone_id   = module.trial_vnet.webapp_dns_zone_id
 
   settings = merge(
     local.common_settings,
@@ -172,6 +202,7 @@ module "trial_sc_gateway" {
     azurerm_application_insights.app_insights,
     module.trial_sc_config,
     module.trial_sc_discovery,
+    module.trial_vnet,
   ]
 }
 
@@ -184,18 +215,23 @@ module "trial_sc_discovery" {
   environment         = var.environment
   docker_image        = var.sc_discovery_image_name
   docker_image_tag    = var.sc_discovery_image_tag
+  vnet_id             = module.trial_vnet.id
+  subnet_id           = module.trial_vnet.endpointsubnet
+  dns_zone_name       = module.trial_vnet.webapp_dns_zone_name
+  dns_zone_id         = module.trial_vnet.webapp_dns_zone_id
 
   settings = {
     "SPRING_PROFILES_ACTIVE"                = var.spring_profile
     "SERVER_PORT"                           = 80
     "WEBSITES_PORT"                         = 80
     "APPLICATIONINSIGHTS_CONNECTION_STRING" = azurerm_application_insights.app_insights.connection_string
-    "EUREKA_ENVIRONMENT" = var.environment # for a label in the eureka status screen
+    "EUREKA_ENVIRONMENT"                    = var.environment # for a label in the eureka status screen
   }
 
   depends_on = [
     azurerm_app_service_plan.apps_service_plan,
     azurerm_application_insights.app_insights,
+    module.trial_vnet,
   ]
 }
 
@@ -208,6 +244,10 @@ module "trial_sc_config" {
   environment         = var.environment
   docker_image        = var.sc_config_image_name
   docker_image_tag    = var.sc_config_image_tag
+  vnet_id             = module.trial_vnet.id
+  subnet_id           = module.trial_vnet.endpointsubnet
+  dns_zone_name       = module.trial_vnet.webapp_dns_zone_name
+  dns_zone_id         = module.trial_vnet.webapp_dns_zone_id
 
   # optted not to use the common settings since it includes a config label that might casue problems here.
   settings = {
@@ -219,12 +259,15 @@ module "trial_sc_config" {
     "WEBSITES_PORT"                              = 80
     "EUREKA_CLIENT_SERVICEURL_DEFAULTZONE"       = "${module.trial_sc_discovery.hostname}/eureka/"
     "APPLICATIONINSIGHTS_CONNECTION_STRING"      = azurerm_application_insights.app_insights.connection_string
+    "WEBSITE_DNS_SERVER"                         = "168.63.129.16"
+    "WEBSITE_VNET_ROUTE_ALL"                     = 1
   }
 
   depends_on = [
     azurerm_app_service_plan.apps_service_plan,
     azurerm_application_insights.app_insights,
     module.trial_sc_discovery,
+    module.trial_vnet,
   ]
 }
 


### PR DESCRIPTION
## Description
Limit public/internet access to API services.
ALL SQL, KV  and web apps (except gateway) are now inside a vnet and communicate using vnet integration + private endpoints.
the gateway has vnet integration for outbound connections and remains publicly available.

### Changes
- [ARTS- 355] - Limit public/internet access to API services.

### Checklist:

- [x] Branch name follows convention (feature/arts-###-short-name OR fix/arts-###-short-name)
- [x] I have included a short-meaningful title, description and changes for this PR
