### PR TITLE
[ARTS-620] - Remove adding roles as MTS repo will break

### DIFF
--- a/trials/ci-trial/services/init-service/application-dev.yml
+++ b/trials/ci-trial/services/init-service/application-dev.yml
@@ -52,7 +52,6 @@ trial:
       permissions:
         - id: create-person
         - id: view-person
-        - id: assign-role
     - id: admin
       permissions:
         - id: create-person

--- a/trials/sample2/services/init-service/application-dev.yml
+++ b/trials/sample2/services/init-service/application-dev.yml
@@ -52,7 +52,6 @@ trial:
       permissions:
         - id: create-person
         - id: view-person
-        - id: assign-role
     - id: admin
       permissions:
         - id: create-person


### PR DESCRIPTION
## Description
Remove adding roles as MTS repo will break. We need the Liquibase and the config files that contain users/roles to be in sync otherwise when init-service starts when building/deploying in MTS the service will throw a BAD_REQUEST error due to the role in the config file not being present in the MTS Role DB.

### Changes
- [ARTS-620] - this a fix form a defect created in 620 work

### Checklist:

- [ ] Branch name follows convention (feature/arts-###-short-name OR fix/arts-###-short-name)
- [ ] I have included a short-meaningful title, description and changes for this PR


[ARTS-620]: https://ndph-arts.atlassian.net/browse/ARTS-620