### PR TITLE
[ARTS-346] Role-service config fix

### DIFF
--- a/trials/ci-trial/services/role-service/application-dev.yml
+++ b/trials/ci-trial/services/role-service/application-dev.yml
@@ -1,3 +1,13 @@
+spring:
+  liquibase:
+    change-log: classpath:db/changelog/changelog-role-service-master.xml
+    drop-first: false
+    enabled: true
+  jpa:
+    hibernate:
+      ddl-auto: none
+  hateoas:
+    use-hal-as-default-json-media-type: false
 server:
   error:
     include-message: always

--- a/trials/qa1/services/role-service/application-dev.yml
+++ b/trials/qa1/services/role-service/application-dev.yml
@@ -1,3 +1,13 @@
+spring:
+  liquibase:
+    change-log: classpath:db/changelog/changelog-role-service-master.xml
+    drop-first: false
+    enabled: true
+  jpa:
+    hibernate:
+      ddl-auto: none
+  hateoas:
+    use-hal-as-default-json-media-type: false
 server:
   error:
     include-message: always

--- a/trials/sample2/services/role-service/application-dev.yml
+++ b/trials/sample2/services/role-service/application-dev.yml
@@ -1,3 +1,13 @@
+spring:
+  liquibase:
+    change-log: classpath:db/changelog/changelog-role-service-master.xml
+    drop-first: false
+    enabled: true
+  jpa:
+    hibernate:
+      ddl-auto: none
+  hateoas:
+    use-hal-as-default-json-media-type: false
 server:
   error:
     include-message: always


### PR DESCRIPTION
## Description
The previous change for 346 to server config files was added to the sample_trial directory which has been deleted/replaced by ci dirs. This adds the liquibase config to the correct dirs

### Changes
- [ARTS-346] - resolve config dir issue

### Checklist:

- [ ] Branch name follows convention (feature/arts-###-short-name OR fix/arts-###-short-name)
- [ ] I have included a short-meaningful title, description and changes for this PR


[ARTS-346]: https://ndph-arts.atlassian.net/browse/ARTS-346