### PR TITLE
Use a single secret by including the terraform resource group name

### DIFF
--- a/.github/workflows/terraform-plan-apply.yml
+++ b/.github/workflows/terraform-plan-apply.yml
@@ -153,7 +153,6 @@ jobs:
       ARM_CLIENT_SECRET: ${{secrets.TF_ARM_CLIENT_SECRET}}
       ARM_SUBSCRIPTION_ID: f3fba52d-c7db-46f8-9e7a-766ca869972e
       ARM_TENANT_ID: 99804659-431f-48fa-84c1-65c9609de05b
-      ARM_ACCESS_KEY: ${{secrets.TF_ARM_ACCESS_KEY}}
     steps:
       - uses: actions/checkout@v2
 

--- a/terraform/provider.tf
+++ b/terraform/provider.tf
@@ -7,6 +7,9 @@ terraform {
   }
 
   backend "azurerm" {
+    # including the resource group allows us to supply just 1 secret for access.
+    # however, this assumes that the terraform state storage account is on the same subscription as the resources deployed.
+    resource_group_name  = "rg-terraform-backend"
     storage_account_name = "oxterraformbackend"
     container_name       = "terraform-state"
     key                  = "terraform.tfstate"


### PR DESCRIPTION
## Description
By providing terraform the name for the resource group holding the state storage account we can use a single secret rather than 2. Terraform will use the remaining secret to look for the storage account in the group and fetch its credentials from there.

After this PR will be merged we could delete the TF_ARM_ACCESS_KEY secret from this repo.

### Checklist:

- [ ] Branch name follows convention (feature/arts-###-short-name OR fix/arts-###-short-name)
- [x] I have included a short-meaningful title, description and changes for this PR
