### PR TITLE
[FIX] Role service warmup limit

### DIFF
--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -103,6 +103,8 @@ module "trial_app_service_role" {
       "JDBC_DRIVER" = "com.microsoft.sqlserver.jdbc.SQLServerDriver"
       # TODO: replace with KeyVault reference
       "JDBC_URL" = "jdbc:sqlserver://${module.roles_sql_server.sqlserver_name}.database.windows.net:1433;databaseName=ROLES;user=${module.roles_sql_server.db_user};password=${module.roles_sql_server.db_password}"
+      # since this service does db migrations, interuptting it will render the whole env useless (due to the db "lock").
+      "WEBSITES_CONTAINER_START_TIME_LIMIT" = 600 # default is 230
     },
   )
 


### PR DESCRIPTION
## Description
Role service is using a db migration tool (liquibase) that if interrupted renders the whole environment useless. This PR increases the time allowed for the container to warm-up before app-service forcibly kills it.

### Checklist:

- [ ] Branch name follows convention (feature/arts-###-short-name OR fix/arts-###-short-name)
- [x] I have included a short-meaningful title, description and changes for this PR
