### PR TITLE
[Fix] move allow bean definition overriding to services that require it

### DIFF
--- a/trials/ci-trial/services/application.yml
+++ b/trials/ci-trial/services/application.yml
@@ -1,8 +1,5 @@
+# GLOBAL config file - all settings will be inherited by services working with the config-server
 management:
-  endpoints:
-    web:
-      exposure:
-        include: "*"
   health:
     probes:
       enabled: true
@@ -12,6 +9,8 @@ azure:
   activedirectory:
     client-id: fa5cde1d-d6f8-4d13-9fa4-4d7a374cb290
     session-stateless: true
+
+# TODO: remove the routes once https://ndph-arts.atlassian.net/browse/ARTS-636 is done
 practitioner:
   service:
     endpoint:
@@ -30,6 +29,3 @@ site:
       sites: /sites
     name: site-service
     uri: http://site-service
-spring:
-  main:
-    allow-bean-definition-overriding: true

--- a/trials/ci-trial/services/practitioner-service-dev.yml
+++ b/trials/ci-trial/services/practitioner-service-dev.yml
@@ -2,6 +2,11 @@ server:
   error:
     include-message: always
 
+spring:
+  main:
+    # Required for the security package
+    allow-bean-definition-overriding: true
+
 mts:
   practitioner:
     name: Practitioner

--- a/trials/ci-trial/services/role-service-dev.yml
+++ b/trials/ci-trial/services/role-service-dev.yml
@@ -8,6 +8,9 @@ spring:
       ddl-auto: none
   hateoas:
     use-hal-as-default-json-media-type: false
+  main:
+    # Required for the security package
+    allow-bean-definition-overriding: true
 server:
   error:
     include-message: always

--- a/trials/ci-trial/services/site-service-dev.yml
+++ b/trials/ci-trial/services/site-service-dev.yml
@@ -1,6 +1,10 @@
 server:
   error:
     include-message: always
+spring:
+  main:
+    # Required for the security package
+    allow-bean-definition-overriding: true
 fhir:
   resultCount: 50
 

--- a/trials/mainnightly/services/application.yml
+++ b/trials/mainnightly/services/application.yml
@@ -1,15 +1,16 @@
+# GLOBAL config file - all settings will be inherited by services working with the config-server
 management:
-  endpoints:
-    web:
-      exposure:
-        include: "*"
+  health:
+    probes:
+      enabled: true
 
 #security config
-
 azure:
   activedirectory:
     client-id: fa5cde1d-d6f8-4d13-9fa4-4d7a374cb290
     session-stateless: true
+
+# TODO: remove the routes once https://ndph-arts.atlassian.net/browse/ARTS-636 is done
 practitioner:
   service:
     endpoint:
@@ -28,6 +29,3 @@ site:
       sites: /sites
     name: site-service
     uri: http://site-service
-spring:
-  main:
-    allow-bean-definition-overriding: true

--- a/trials/mainnightly/services/practitioner-service-dev.yml
+++ b/trials/mainnightly/services/practitioner-service-dev.yml
@@ -2,6 +2,11 @@ server:
   error:
     include-message: always
 
+spring:
+  main:
+    # Required for the security package
+    allow-bean-definition-overriding: true
+
 mts:
   practitioner:
     name: Practitioner

--- a/trials/mainnightly/services/role-service-dev.yml
+++ b/trials/mainnightly/services/role-service-dev.yml
@@ -8,6 +8,9 @@ spring:
       ddl-auto: none
   hateoas:
     use-hal-as-default-json-media-type: false
+  main:
+    # Required for the security package
+    allow-bean-definition-overriding: true
 server:
   error:
     include-message: always

--- a/trials/mainnightly/services/site-service-dev.yml
+++ b/trials/mainnightly/services/site-service-dev.yml
@@ -1,6 +1,10 @@
 server:
   error:
     include-message: always
+spring:
+  main:
+    # Required for the security package
+    allow-bean-definition-overriding: true
 fhir:
   resultCount: 50
 


### PR DESCRIPTION
## Description
allow-bean-definition-overriding should be used only where really required. This fix moved it from the root application.yml to the service level.

### Checklist:

- [ ] Branch name follows convention (feature/arts-###-short-name OR fix/arts-###-short-name)
- [x] I have included a short-meaningful title, description and changes for this PR
