### PR TITLE
Default region set to eastus2 (was uksouth)

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -17,7 +17,7 @@ variable "environment" {
 variable "location" {
   type        = string
   description = "Azure region where to create resources."
-  default     = "uksouth"
+  default     = "eastus2"
 }
 
 


### PR DESCRIPTION
## Description
Set the default region to eastus2 to save around 10% of Azure spend.

### Checklist:

- [ ] Branch name follows convention (feature/arts-###-short-name OR fix/arts-###-short-name)
- [x] I have included a short-meaningful title, description and changes for this PR
