### PR TITLE
[FIX] - Reduce the delay-start time, so the init will start faster

### DIFF
--- a/trials/ci-trial/services/init-service-dev.yml
+++ b/trials/ci-trial/services/init-service-dev.yml
@@ -16,7 +16,7 @@ logging:
             function:
               client:
                 ExchangeFunctions: TRACE
-delay-start: 120
+delay-start: 10
 
 http:
   readTimeOutMs: 30000

--- a/trials/mainnightly/services/init-service-dev.yml
+++ b/trials/mainnightly/services/init-service-dev.yml
@@ -16,7 +16,7 @@ logging:
             function:
               client:
                 ExchangeFunctions: TRACE
-delay-start: 120
+delay-start: 30
 
 http:
   readTimeOutMs: 30000

--- a/trials/qa1/services/init-service-dev.yml
+++ b/trials/qa1/services/init-service-dev.yml
@@ -16,7 +16,7 @@ logging:
             function:
               client:
                 ExchangeFunctions: TRACE
-delay-start: 120
+delay-start: 30
 
 http:
   readTimeOutMs: 30000

--- a/trials/sample2/services/init-service-dev.yml
+++ b/trials/sample2/services/init-service-dev.yml
@@ -16,7 +16,7 @@ logging:
             function:
               client:
                 ExchangeFunctions: TRACE
-delay-start: 120
+delay-start: 30
 
 http:
   readTimeOutMs: 30000


### PR DESCRIPTION
## Description
Reduce the delay-start time, so the init will start faster.
Now that the init doesn't start until all services are registered we can start it sooner
We leave some delay as its not expected to be available from the start.

### Checklist:

- [ ] Branch name follows convention (feature/arts-###-short-name OR fix/arts-###-short-name)
- [ ] I have included a short-meaningful title, description and changes for this PR
