### PR TITLE
[Fix] removing xtrace flag

### DIFF
--- a/.github/workflows/terraform-plan-apply.yml
+++ b/.github/workflows/terraform-plan-apply.yml
@@ -387,7 +387,7 @@ jobs:
         # if: github.ref == 'refs/heads/main'
         run: |
           set -o nounset
-          set -o xtrace
+          #set -o xtrace
           # can't use errexit and pipefail flags here becasue tail will fail if the file doesn't exists
 
           echo "Trying to download init service log in loop, timeout set to 60 min."


### PR DESCRIPTION
## Description
removing xtrace flag to reduce tracing logs which meant for debugging and got merged by mistake.


### Checklist:

- [✔ ] Branch name follows convention (feature/arts-###-short-name OR fix/arts-###-short-name)
- [✔ ] I have included a short-meaningful title, description and changes for this PR
