### PR TITLE
[ARTS-760] Github action to inject versions info into UI

### DIFF
--- a/.github/workflows/terraform-plan-apply.yml
+++ b/.github/workflows/terraform-plan-apply.yml
@@ -191,7 +191,7 @@ jobs:
       ARM_CLIENT_SECRET: ${{secrets.TF_ARM_CLIENT_SECRET}}
       ARM_SUBSCRIPTION_ID: f3fba52d-c7db-46f8-9e7a-766ca869972e
       ARM_TENANT_ID: 99804659-431f-48fa-84c1-65c9609de05b
-      UI_VERSION : https://github.com/NDPH-ARTS/mts-trial-ui/releases/latest/download/mts-trial-ui.zip
+      UI_BUNDLE : https://github.com/NDPH-ARTS/mts-trial-ui/releases/latest/download/mts-trial-ui.zip
     steps:
       - uses: actions/checkout@v2
 
@@ -281,7 +281,7 @@ jobs:
           echo "Preparing versions json for injection into UI - read ${{ matrix.definition_path }} write ${{ matrix.trial_name }}_versions.json "
 
           # Use YQ to convert definition.yml to json, use JQ to recurse through the json finding image_tag nodes and their keys, write to a file
-          yq eval -j ${{ matrix.definition_path }} | jq '[ ..  | objects | to_entries  | .[] | select(.value | has("image_tag"))? | {service:.key, version:.value.image_tag, timestamp:now} ] | .+ [{service:"UI", version:env.UI_VERSION, timestamp:now} ] ' >> ${{ matrix.trial_name }}_versions.json
+          yq eval -j ${{ matrix.definition_path }} | jq '[ ..  | objects | to_entries  | .[] | select(.value | has("image_tag"))? | {service:.key, version:.value.image_tag, timestamp:now} ] | .+ [{service:"UI", version:env.UI_BUNDLE, timestamp:now} ] ' >> ${{ matrix.trial_name }}_versions.json
 
           # NB UI_VERSION is a static placeholder for now - will become dynamic in future story
           
@@ -354,7 +354,7 @@ jobs:
           set -o errexit
           set -o nounset
 
-          wget ${UI_VERSION}
+          wget ${UI_BUNDLE}
 
 
       # Unzip & Customize (replace values)

--- a/.github/workflows/terraform-plan-apply.yml
+++ b/.github/workflows/terraform-plan-apply.yml
@@ -246,6 +246,7 @@ jobs:
           ref_for_workspace="${GITHUB_REF//\//_}"
           workspace_name="${{ matrix.trial_name }}-${ref_for_workspace}"
           terraform workspace select ${workspace_name} || terraform workspace new ${workspace_name}
+
       - name: Prepare deployment variables
         env:
           TFVARS_TEMPLATE: 'tfvars.template.yml'
@@ -268,6 +269,25 @@ jobs:
           # extract more values from the definition file to inject to the ui resources
           echo "tenant_id=$(yq eval '.tenant_id' ${{ matrix.definition_path }})" >> $GITHUB_ENV
           echo "ui_client_id=$(yq eval '.ui_client_id' ${{ matrix.definition_path }})" >> $GITHUB_ENV
+
+      # Prepare versions json
+      - name: Prepare versions json
+        run: |
+          set -o errexit
+          set -o pipefail
+          set -o nounset
+
+          echo "Preparing versions json for injection into UI - read ${{ matrix.definition_path }} write ${{ matrix.trial_name }}_versions.json "
+
+
+          # NB UI_VERSION is a static placeholder for now - will become dynamic in future story
+          echo "UI_VERSION=https://github.com/NDPH-ARTS/mts-trial-ui/releases/latest/download/mts-trial-ui.zip" >> $GITHUB_ENV
+
+          # Use YQ to convert definition.yml to json, use JQ to recurse through the json finding image_tag nodes and their keys, write to a file
+          yq eval -j ${{ matrix.definition_path }} | jq '[ ..  | objects | to_entries  | .[] | select(.value | has("image_tag"))? | {service:.key, version:.value.image_tag, timestamp:now} ] | .+ [{service:"UI", version:env.UI_VERSION, timestamp:now} ] ' >> ${{ matrix.trial_name }}_versions.json
+
+          cat ${{ matrix.trial_name }}_versions.json
+
 
       # Plan TF
       - name: Terraform plan
@@ -335,7 +355,8 @@ jobs:
           set -o errexit
           set -o nounset
 
-          wget https://github.com/NDPH-ARTS/mts-trial-ui/releases/latest/download/mts-trial-ui.zip
+          wget ${UI_VERSION}
+
 
       # Unzip & Customize (replace values)
       - name: UI component - Unzip and modify
@@ -356,6 +377,7 @@ jobs:
           sed -i "s/{{trialName}}/${trial_name}/" ${index_file}
           sed -i "s^{{gatewayUrl}}^${gateway_host_string}/api^" ${index_file}
 
+
       # Add Branding Assets
       - name: UI component - copy assets
         run: |
@@ -367,6 +389,17 @@ jobs:
           echo "using trial path ${{ matrix.trial_dir }}"
           # copy everything in the assets folder
           cp -fr ${{ matrix.trial_dir }}/assets/* mts-trial-ui/assets/
+
+
+      # Inject versions json
+      - name: UI component - inject versions info into UI
+        run: |
+          set -o errexit
+          set -o pipefail
+          set -o nounset
+
+          # copy the versions file into the UI
+          cp -f ${{ matrix.trial_name }}_versions.json mts-trial-ui/assets/versions.json
 
       # Upload to storage account (to $web container)
       - name: UI component - Upload to storage

--- a/.github/workflows/terraform-plan-apply.yml
+++ b/.github/workflows/terraform-plan-apply.yml
@@ -191,6 +191,7 @@ jobs:
       ARM_CLIENT_SECRET: ${{secrets.TF_ARM_CLIENT_SECRET}}
       ARM_SUBSCRIPTION_ID: f3fba52d-c7db-46f8-9e7a-766ca869972e
       ARM_TENANT_ID: 99804659-431f-48fa-84c1-65c9609de05b
+      UI_VERSION : https://github.com/NDPH-ARTS/mts-trial-ui/releases/latest/download/mts-trial-ui.zip
     steps:
       - uses: actions/checkout@v2
 
@@ -279,13 +280,11 @@ jobs:
 
           echo "Preparing versions json for injection into UI - read ${{ matrix.definition_path }} write ${{ matrix.trial_name }}_versions.json "
 
-
-          # NB UI_VERSION is a static placeholder for now - will become dynamic in future story
-          echo "UI_VERSION=https://github.com/NDPH-ARTS/mts-trial-ui/releases/latest/download/mts-trial-ui.zip" >> $GITHUB_ENV
-
           # Use YQ to convert definition.yml to json, use JQ to recurse through the json finding image_tag nodes and their keys, write to a file
           yq eval -j ${{ matrix.definition_path }} | jq '[ ..  | objects | to_entries  | .[] | select(.value | has("image_tag"))? | {service:.key, version:.value.image_tag, timestamp:now} ] | .+ [{service:"UI", version:env.UI_VERSION, timestamp:now} ] ' >> ${{ matrix.trial_name }}_versions.json
 
+          # NB UI_VERSION is a static placeholder for now - will become dynamic in future story
+          
           cat ${{ matrix.trial_name }}_versions.json
 
 

--- a/.github/workflows/terraform-plan-apply.yml
+++ b/.github/workflows/terraform-plan-apply.yml
@@ -271,7 +271,7 @@ jobs:
           echo "tenant_id=$(yq eval '.tenant_id' ${{ matrix.definition_path }})" >> $GITHUB_ENV
           echo "ui_client_id=$(yq eval '.ui_client_id' ${{ matrix.definition_path }})" >> $GITHUB_ENV
 
-      # Prepare versions json
+      # Prepare versions json, write it to assets directory
       - name: Prepare versions json
         run: |
           set -o errexit
@@ -281,11 +281,9 @@ jobs:
           echo "Preparing versions json for injection into UI - read ${{ matrix.definition_path }} write ${{ matrix.trial_name }}_versions.json "
 
           # Use YQ to convert definition.yml to json, use JQ to recurse through the json finding image_tag nodes and their keys, write to a file
-          yq eval -j ${{ matrix.definition_path }} | jq '[ ..  | objects | to_entries  | .[] | select(.value | has("image_tag"))? | {service:.key, version:.value.image_tag, timestamp:now} ] | .+ [{service:"UI", version:env.UI_BUNDLE, timestamp:now} ] ' >> ${{ matrix.trial_name }}_versions.json
+          yq eval -j ${{ matrix.definition_path }} | jq '[ ..  | objects | to_entries  | .[] | select(.value | has("image_tag"))? | {service:.key, version:.value.image_tag, timestamp:now} ] | .+ [{service:"UI", version:env.UI_BUNDLE, timestamp:now} ] ' >> ${{ matrix.trial_dir }}/assets/versions.json
 
-          # NB UI_VERSION is a static placeholder for now - will become dynamic in future story
-          
-          cat ${{ matrix.trial_name }}_versions.json
+          cat ${{ matrix.trial_dir }}/assets/versions.json
 
 
       # Plan TF
@@ -389,16 +387,6 @@ jobs:
           # copy everything in the assets folder
           cp -fr ${{ matrix.trial_dir }}/assets/* mts-trial-ui/assets/
 
-
-      # Inject versions json
-      - name: UI component - inject versions info into UI
-        run: |
-          set -o errexit
-          set -o pipefail
-          set -o nounset
-
-          # copy the versions file into the UI
-          cp -f ${{ matrix.trial_name }}_versions.json mts-trial-ui/assets/versions.json
 
       # Upload to storage account (to $web container)
       - name: UI component - Upload to storage


### PR DESCRIPTION
## Description
* Use jq/yq to read image_tag docker version data from definition.yml and write a json file
* Add build timestamp And UI version zip
* Inject json into UI 

Companion angular PR is here: https://github.com/NDPH-ARTS/mts-trial-ui/pull/28

Example azure deployment: https://sakate760muidev.z20.web.core.windows.net/assets/versions.json

### Changes
- [ARTS-760] 

### Checklist:

- [x] Branch name follows convention (feature/arts-###-short-name OR fix/arts-###-short-name)
- [x] I have included a short-meaningful title, description and changes for this PR


[ARTS-760]: https://ndph-arts.atlassian.net/browse/ARTS-760