### PR TITLE
Update terraform-plan-apply.yml

### DIFF
--- a/.github/workflows/terraform-plan-apply.yml
+++ b/.github/workflows/terraform-plan-apply.yml
@@ -231,6 +231,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v1
         with:
+          terraform_version: 0.14.10
           terraform_wrapper: false
 
       - name: Terraform Init


### PR DESCRIPTION
## Description
TF ver 15.0 has broken a couple of files that use list("") - this has been deprecated since TF v12.0 but they have not completely removed that function so an error occurs. Ive added terraform_version: 0.14.10 to the terraform-plan-apply file to ensure we dont update to the latest version when running TF. We can use this version for the short term but will needd to spend time to update the functions correctly to allow using the latest versions of TF. 

### Changes

### Checklist:

- [ ] Branch name follows convention (feature/arts-###-short-name OR fix/arts-###-short-name)
- [ ] I have included a short-meaningful title, description and changes for this PR
