### PR TITLE
revert removal of init service log download

### DIFF
--- a/.github/workflows/terraform-plan-apply.yml
+++ b/.github/workflows/terraform-plan-apply.yml
@@ -402,6 +402,44 @@ jobs:
           az storage blob delete-batch --connection-string ${ui_storage_conn_string} --source "\$web" --pattern "*"
           az storage blob upload-batch --connection-string ${ui_storage_conn_string} --source mts-trial-ui --destination '$web'
 
+      # Download init service progress log file from azure file share and validate success
+      - name: Validate Init service progress
+        timeout-minutes: 60
+        # if: github.ref == 'refs/heads/main'
+        run: |
+          set -o nounset
+          #set -o xtrace
+          # can't use errexit and pipefail flags here becasue tail will fail if the file doesn't exists
+
+          echo "Trying to download init service log in loop, timeout set to 60 min."
+          lines_in_previous_file=0
+          start_time="$(date -u +%s)"
+          while :
+          do
+            until az storage file download --no-progress --output none --path log.txt --share-name ${init_storage_share_name} --connection-string ${init_storage_conn_string} > /dev/null 2>&1
+            do
+              time_stamp="$(date -u +%s)"
+              echo "Log file isn't there yet. Sleeping... $(($time_stamp-$start_time))s"
+              sleep 10
+            done
+
+            # check how many lines in the new file and print only the new lines from previous iteration
+            lines_in_new_file=$(cat log.txt | wc -l)
+            delta=$(("$lines_in_new_file" - "$lines_in_previous_file"))
+            if [[ $delta -gt 0 ]]; then
+              tail log.txt -n $delta
+              lines_in_previous_file=$lines_in_new_file
+              if (tail log.txt --lines 1 | grep -q "SUCCESS")
+              then
+                  echo "Init service - Completed Successfully"
+                  exit 0
+              fi
+            fi
+
+            time_stamp="$(date -u +%s)"
+            echo "Didn't find SUCCESS message, Sleeping... $(($time_stamp-$start_time))s"
+            sleep 10
+          done
   deployall:
     runs-on: ubuntu-latest
     name: Terraform plan/apply (matrix)


### PR DESCRIPTION
## Description
This is to revert the removal of the init service log download which wasnt completing and therefore causing confusion if the env was created, in a very typical fashion the build/deploy now seems to work as expected when using the init service log download code...so this PR is to to revert the file and not add anything extra.

initial revert/removal of init service download code  -https://github.com/NDPH-ARTS/mts-trial-deployment-config/pull/126

### Checklist:

- [ ] Branch name follows convention (feature/arts-###-short-name OR fix/arts-###-short-name)
- [ ] I have included a short-meaningful title, description and changes for this PR
